### PR TITLE
Use metabrainz PPA instead of oliver-charles

### DIFF
--- a/caa-indexer/recipes/install.rb
+++ b/caa-indexer/recipes/install.rb
@@ -26,7 +26,7 @@ package "libxml-xpath-perl"
 
 include_recipe "apt"
 apt_repository "musicbrainz" do
-  uri "http://ppa.launchpad.net/oliver-charles/musicbrainz/ubuntu"
+  uri "http://ppa.launchpad.net/metabrainz/musicbrainz-server/ubuntu"
   distribution node['lsb']['codename']
   components ["main"]
   keyserver "keyserver.ubuntu.com"

--- a/monitoring/recipes/rabbitmq.rb
+++ b/monitoring/recipes/rabbitmq.rb
@@ -2,7 +2,7 @@ user "monitoring"
 
 include_recipe "apt"
 apt_repository "musicbrainz" do
-  uri "http://ppa.launchpad.net/oliver-charles/musicbrainz/ubuntu"
+  uri "http://ppa.launchpad.net/metabrainz/musicbrainz-server/ubuntu"
   distribution node['lsb']['codename']
   components ["main"]
   keyserver "keyserver.ubuntu.com"

--- a/musicbrainz-server/recipes/install.rb
+++ b/musicbrainz-server/recipes/install.rb
@@ -29,7 +29,7 @@ end
 
 include_recipe "apt"
 apt_repository "musicbrainz" do
-  uri "http://ppa.launchpad.net/oliver-charles/musicbrainz/ubuntu"
+  uri "http://ppa.launchpad.net/metabrainz/musicbrainz-server/ubuntu"
   distribution node['lsb']['codename']
   components ["main"]
   keyserver "keyserver.ubuntu.com"

--- a/postgresql/recipes/default.rb
+++ b/postgresql/recipes/default.rb
@@ -4,7 +4,7 @@ package "postgresql-9.1"
 package "postgresql-contrib-9.1"
 
 apt_repository "musicbrainz" do
-  uri "http://ppa.launchpad.net/oliver-charles/musicbrainz/ubuntu"
+  uri "http://ppa.launchpad.net/metabrainz/musicbrainz-server/ubuntu"
   distribution node['lsb']['codename']
   components ["main"]
   keyserver "keyserver.ubuntu.com"


### PR DESCRIPTION
I've copied all the packages I had over to the musicbrainz-server PPA. The next time you run `provision.sh` Chef should switch PPAs and Just Work.
