### PR TITLE
musicbrainz-server: New without-warnings log file

### DIFF
--- a/musicbrainz-server/templates/default/sv-musicbrainz-server-log-run.erb
+++ b/musicbrainz-server/templates/default/sv-musicbrainz-server-log-run.erb
@@ -1,20 +1,31 @@
 #!/bin/bash
 mkdir -p ./main ./oddlog ./errors
-exec multilog t \
-    +'*' s1000000 n50 ./main \
-    +'*' \
-    -'* Process memory information:*' \
-    -'* [warning] Found size is *' \
-    -'* [warning] Checking Memory Size*' \
-    -'* [warning] Process Info:*' \
-    -'* .------*' \
-    -'* | PID    | VIRT *' \
-    -'* +--------+------*' \
-    -'* |*|*|*| perl-fcgi       |' \
-    -"* '--------+---*" \
-    -'* FastCGI: *' \
-    -'* [warning] wizard session, *' \
-    -'* [error] wizard session, *' \
-    -'* [warning] * is bigger than: *' \
-    -'*$msgid in substitution*' \
-    ./oddlog \
+exec multilog t                                                    \
+    +'*' s1000000 n50                                              \
+    ./main                                                         \
+    +'*'                                                           \
+    -'* Process memory information:*'                              \
+    -'* [warning] Found size is *'                                 \
+    -'* [warning] Checking Memory Size*'                           \
+    -'* [warning] Process Info:*'                                  \
+    -'*.--------+--------------+--------------+-----------------.' \
+    -'*| PID    | VIRT         | RES          | COMMAND         |' \
+    -'*+--------+--------------+--------------+-----------------+' \
+    -'*|*|*|*|*|'                                                  \
+    -"*'--------+--------------+--------------+-----------------"  \
+    -'* FastCGI: *'                                                \
+    -'* [warning] wizard session, *'                               \
+    -'* [error] wizard session, *'                                 \
+    -'* [warning] * is bigger than: *'                             \
+    -'*$msgid in substitution*'                                    \
+    ./oddlog                                                       \
+    +'*'                                                           \
+    -'*[warning]*'                                                 \
+    -'*[debug] Checking Memory Size.'                              \
+    -'*[debug] Process Info:'                                      \
+    -'*.--------+--------------+--------------+-----------------.' \
+    -'*| PID    | VIRT         | RES          | COMMAND         |' \
+    -'*+--------+--------------+--------------+-----------------+' \
+    -'*|*|*|*|*|'                                                  \
+    -"*'--------+--------------+--------------+-----------------"  \
+    ./errors


### PR DESCRIPTION
Adds a new target to the musicbrainz-server daemontools service that
discards any log lines that match the pattern '\* [warning] *'.
