### PR TITLE
Add a separate service for ws traffic

### DIFF
--- a/musicbrainz-server/recipes/production.rb
+++ b/musicbrainz-server/recipes/production.rb
@@ -15,7 +15,17 @@ end
 daemontools_service "musicbrainz-server" do
   directory "/home/musicbrainz/svc-musicbrainz-server"
   template "musicbrainz-server"
-  variables :nproc => node['musicbrainz-server']['nproc']
+  variables :nproc => node['musicbrainz-server']['nproc-website']
+  action [:enable,:start]
+  subscribes :restart, "git[/home/musicbrainz/musicbrainz-server]"
+  subscribes :restart, "template[/home/musicbrainz/musicbrainz-server/lib/DBDefs.pm]"
+  log true
+end
+
+daemontools_service "musicbrainz-ws" do
+  directory "/home/musicbrainz/svc-musicbrainz-ws"
+  template "musicbrainz-server"
+  variables :nproc => node['musicbrainz-server']['nproc-ws']
   action [:enable,:start]
   subscribes :restart, "git[/home/musicbrainz/musicbrainz-server]"
   subscribes :restart, "template[/home/musicbrainz/musicbrainz-server/lib/DBDefs.pm]"

--- a/musicbrainz-server/recipes/production.rb
+++ b/musicbrainz-server/recipes/production.rb
@@ -24,7 +24,7 @@ end
 
 daemontools_service "musicbrainz-ws" do
   directory "/home/musicbrainz/svc-musicbrainz-ws"
-  template "musicbrainz-server"
+  template "musicbrainz-ws"
   variables :nproc => node['musicbrainz-server']['nproc-ws']
   action [:enable,:start]
   subscribes :restart, "git[/home/musicbrainz/musicbrainz-server]"

--- a/musicbrainz-server/templates/default/nginx.conf.erb
+++ b/musicbrainz-server/templates/default/nginx.conf.erb
@@ -79,6 +79,22 @@ cation/xml application/xml+rss text/javascript;
         gzip_buffers 16 8k;
     }
 
+    location /ws/ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $http_x_mb_remote_addr;
+        proxy_pass http://unix:/home/musicbrainz/musicbrainz-server/musicbrainz-ws.socket:;
+
+        gzip  on;
+        gzip_http_version 1.0;
+        gzip_comp_level 6;
+        gzip_proxied any;
+        gzip_types text/plain text/html text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+        # make sure gzip does not lose large gzipped js or css files
+        # see http://blog.leetsoft.com/2007/7/25/nginx-gzip-ssl
+        gzip_buffers 16 8k;
+    }
+
     location ~* ^/internal/search/(.*?)/(.*) {
         internal;
 

--- a/musicbrainz-server/templates/default/nginx.conf.erb
+++ b/musicbrainz-server/templates/default/nginx.conf.erb
@@ -79,7 +79,7 @@ cation/xml application/xml+rss text/javascript;
         gzip_buffers 16 8k;
     }
 
-    location /ws/ {
+    location ~* ^/ws/[12]/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $http_x_mb_remote_addr;

--- a/musicbrainz-server/templates/default/sv-musicbrainz-ws-log-run.erb
+++ b/musicbrainz-server/templates/default/sv-musicbrainz-ws-log-run.erb
@@ -1,0 +1,20 @@
+#!/bin/bash
+mkdir -p ./main ./oddlog ./errors
+exec multilog t \
+    +'*' s1000000 n50 ./main \
+    +'*' \
+    -'* Process memory information:*' \
+    -'* [warning] Found size is *' \
+    -'* [warning] Checking Memory Size*' \
+    -'* [warning] Process Info:*' \
+    -'* .------*' \
+    -'* | PID    | VIRT *' \
+    -'* +--------+------*' \
+    -'* |*|*|*| perl-fcgi       |' \
+    -"* '--------+---*" \
+    -'* FastCGI: *' \
+    -'* [warning] wizard session, *' \
+    -'* [error] wizard session, *' \
+    -'* [warning] * is bigger than: *' \
+    -'*$msgid in substitution*' \
+    ./oddlog \

--- a/musicbrainz-server/templates/default/sv-musicbrainz-ws-run.erb
+++ b/musicbrainz-server/templates/default/sv-musicbrainz-ws-run.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo starting
+exec 2>&1
+set -e
+cd mb_server
+umask 022
+exec \
+    env MUSICBRAINZ_USE_PROXY=1 starman -Ilib \
+        --preload-app \
+        -E deployment \
+        --listen musicbrainz-ws.socket \
+        --workers <%= @variables[:nproc] || 5 %> \
+        --user www-data \
+        --group www-data


### PR DESCRIPTION
Luks suggested this in #musicbrainz-devel and it seems like a very sound idea - I split the current worker procs 10:40 with 10 going to / and 40 going to /ws/. Might need tweaking.

This is probably something that'd happen eventually anyway if we split out musicbrainz-ws from musicbrainz-server.