### PR TITLE
Switch to Starlet + Server::Starter for graceful restarts

### DIFF
--- a/musicbrainz-server/recipes/production.rb
+++ b/musicbrainz-server/recipes/production.rb
@@ -5,7 +5,7 @@ include_recipe "nodejs"
 
 package "libcatalyst-plugin-autorestart-perl"
 package "libcatalyst-plugin-errorcatcher-perl"
-package "starman"
+package "libstarlet-perl"
 
 service "svscan" do
   action :start

--- a/musicbrainz-server/templates/default/sv-musicbrainz-server-run.erb
+++ b/musicbrainz-server/templates/default/sv-musicbrainz-server-run.erb
@@ -5,10 +5,14 @@ set -e
 cd mb_server
 umask 022
 exec \
-    env MUSICBRAINZ_USE_PROXY=1 starman -Ilib \
-        --preload-app \
-        -E deployment \
-        --listen musicbrainz-server.socket \
-        --workers <%= @variables[:nproc] || 5 %> \
-        --user www-data \
-        --group www-data
+    env MUSICBRAINZ_USE_PROXY=1 \
+        setuidgid www-data \
+            start_server --path musicbrainz-server.socket -- \
+                plackup \
+                    -Ilib \
+                    --server Starlet \
+                    --env deployment \
+                    --max-workers <%= @variables[:nproc] || 5 %> \
+                    --min-reqs-per-child 100 \
+                    --max-reqs-per-child 1000 \
+                    app.psgi

--- a/musicbrainz-server/templates/default/sv-musicbrainz-ws-run.erb
+++ b/musicbrainz-server/templates/default/sv-musicbrainz-ws-run.erb
@@ -5,10 +5,14 @@ set -e
 cd mb_server
 umask 022
 exec \
-    env MUSICBRAINZ_USE_PROXY=1 starman -Ilib \
-        --preload-app \
-        -E deployment \
-        --listen musicbrainz-ws.socket \
-        --workers <%= @variables[:nproc] || 5 %> \
-        --user www-data \
-        --group www-data
+    env MUSICBRAINZ_USE_PROXY=1 \
+        setuidgid www-data \
+            start_server --path musicbrainz-server.socket -- \
+                plackup \
+                    -Ilib \
+                    --server Starlet \
+                    --env deployment \
+                    --max-workers <%= @variables[:nproc] || 5 %> \
+                    --min-reqs-per-child 100 \
+                    --max-reqs-per-child 1000 \
+                    app.psgi


### PR DESCRIPTION
After spending all day packaging these...well here it is. This should make deployment easier since we'll hopefully no longer need to rotate servers. I tested sending SIGHUP to the master `start_server` process on my local machine, and subsequent requests all completed eventually (reloading the random Perl code I changed, too).

The reason I replaced Starman with Starlet is 'cause Starman didn't work in combination with Server::Starter and unix sockets. Starlet is written/maintained by the same person as Server::Starter, and is supposed to be more lightweight than Starman for running behind nginx.