### PR TITLE
Change logster prefix so the node name is in 2nd position

### DIFF
--- a/musicbrainz-server/recipes/logster.rb
+++ b/musicbrainz-server/recipes/logster.rb
@@ -9,7 +9,7 @@ git "/home/musicbrainz/logster" do
 end
 
 logster_log "/var/log/nginx/001-musicbrainz.access.log" do
-    prefix "logster.musicbrainz_server.#{node['hostname']}"
+    prefix "logster.#{node['hostname']}.mbserver"
     output "graphite"
     graphite_host node['graphite']['host']
     parser "musicbrainz.logster.NginxStatus.NginxStatus"


### PR DESCRIPTION
Before we had:
astro.musicbrainz_server.http_2xx

Now:
logster.astro.mbserver.http_2xx

General format is datacollector.node.app.metrics[.metrics]..